### PR TITLE
Fix world map music playing during battles

### DIFF
--- a/WorldMapScene.js
+++ b/WorldMapScene.js
@@ -207,6 +207,9 @@ export default class WorldMapScene extends Phaser.Scene {
 
         if (Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
             if (this.selectedButton === 'Yes') {
+                if (this.soundtrack) {
+                    this.soundtrack.stop();
+                }
                 if (['Rat', 'Mantis', 'Cannibals'].includes(this.chosenEnemy.name)) {
                     this.scene.start('BattleScene');
                 } else {


### PR DESCRIPTION
## Summary
- stop the world map soundtrack when launching a battle or encounter

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_688919357f14832f8fa424d279c7c234