### PR TITLE
Encapsulate global game data

### DIFF
--- a/BattleScene.js
+++ b/BattleScene.js
@@ -1,3 +1,5 @@
+import GameData from './utils/GameData.js';
+
 export default class BattleScene extends Phaser.Scene {
 
     constructor() {
@@ -263,10 +265,10 @@ export default class BattleScene extends Phaser.Scene {
 
     create() {
         this.cameraSpeed = 5
-        this.gameData = this.registry.get('gameData');
+        this.gameData = GameData.get();
         this.gameData.levelLoot = [];
         this.gameData.armorLoot = null;
-        this.registry.set('gameData', this.gameData);
+        GameData.set(this.gameData);
         this.critical_chance = 10
         // Настройка камеры
         this.playRandomSoundtrack();
@@ -542,45 +544,7 @@ export default class BattleScene extends Phaser.Scene {
 
         // hero is dead
         if (this.playerHealth <= 0) {
-            this.registry.set('gameData', {
-                levelCount: 1,
-                health: 30,
-                experience: 0,
-                skills: {
-                    small_guns: 75,
-                    big_guns: 75,
-                    energy_weapons: 75,
-                    melee_weapons: 75,
-                    pyrotechnics: 75,
-                    lockpick: 75,
-                    science: 75,
-                    repair: 75,
-                    medcine: 75,
-                    barter: 75,
-                    speech: 75,
-                    surviving: 75
-                },
-                current_weapon: 'Baseball bat',
-                current_armor: 'Leather Jacket',
-                weapons: ['Baseball bat', '9mm pistol'],
-                med: {
-                    first_aid_kit: 0,
-                    jet: 0,
-                    buffout: 0,
-                    mentats: 0,
-                    psycho: 0
-                },
-                ammo: {
-                    mm_9: 500,
-                    magnum_44: 12,
-                    mm_12: 0,
-                    mm_5_45: 0,
-                    energy_cell: 0,
-                    frag_grenade: 0
-                },
-                enemiesToCreate: [],
-                levelLoot: [],
-            });
+            GameData.reset();
             let toRemove = [];
             this.enemies.forEach((enemy, index) => {
                 enemy.healthIndicator.destroy();
@@ -607,7 +571,7 @@ export default class BattleScene extends Phaser.Scene {
         // escape
         if (this.escape_button.visible && Phaser.Input.Keyboard.JustDown(this.shiftKey)) {
             this.gameData.ammo[this.chosenWeapon.type] += this.bullets_in_current_clip
-            this.registry.set('gameData', this.gameData);
+            GameData.set(this.gameData);
             let toRemove = [];
             this.enemies.forEach((enemy, index) => {
                 enemy.healthIndicator.destroy();
@@ -641,7 +605,7 @@ export default class BattleScene extends Phaser.Scene {
                 let best = this.tempLootArmors.sort((a, b) => armorOrder.indexOf(b) - armorOrder.indexOf(a))[0];
                 this.gameData.armorLoot = best;
             }
-            this.registry.set('gameData', this.gameData);
+            GameData.set(this.gameData);
             let toRemove = [];
             this.enemies.forEach((enemy, index) => {
                 enemy.healthIndicator.destroy();

--- a/EncounterScene.js
+++ b/EncounterScene.js
@@ -1,3 +1,5 @@
+import GameData from './utils/GameData.js';
+
 export default class EncounterScene extends Phaser.Scene {
     constructor() {
         super({ key: 'EncounterScene' });
@@ -70,7 +72,7 @@ export default class EncounterScene extends Phaser.Scene {
     }
 
     handleAskAboutThings() {
-        const speechSkill = this.registry.get('gameData').skills.speech;
+        const speechSkill = GameData.get().skills.speech;
 
         if (Phaser.Math.Between(1, 100) <= speechSkill) {
             console.log('Speech check success')

--- a/VictoryScene.js
+++ b/VictoryScene.js
@@ -1,3 +1,5 @@
+import GameData from './utils/GameData.js';
+
 export default class VictoryScene extends Phaser.Scene {
     constructor() {
         super({ key: 'VictoryScene' });
@@ -41,7 +43,7 @@ export default class VictoryScene extends Phaser.Scene {
     }
 
     create() {
-        this.gameData = this.registry.get('gameData');
+        this.gameData = GameData.get();
         this.add.image(0, 0, 'victory background').setOrigin(0, 0).setScrollFactor(0);
         this.victory_music = this.sound.add('victory music');
         this.victory_music.play()
@@ -127,7 +129,7 @@ export default class VictoryScene extends Phaser.Scene {
 
         this.gameData.levelLoot = [];
         this.gameData.armorLoot = null;
-        this.registry.set('gameData', this.gameData);
+        GameData.set(this.gameData);
 
 
     }

--- a/WorldMapScene.js
+++ b/WorldMapScene.js
@@ -1,3 +1,5 @@
+import GameData from './utils/GameData.js';
+
 export default class WorldMapScene extends Phaser.Scene {
     constructor() {
         
@@ -94,7 +96,7 @@ export default class WorldMapScene extends Phaser.Scene {
     }
 
     create() {
-        this.gameData = this.registry.get('gameData');
+        this.gameData = GameData.get();
         this.playRandomSoundtrack();
         //this.map = this.add.image(0, 0, 'road').setOrigin(0, 0);
 

--- a/mainMenu.js
+++ b/mainMenu.js
@@ -1,3 +1,5 @@
+import GameData from './utils/GameData.js';
+
 export default class MainMenu extends Phaser.Scene {
     constructor() {
         super({ key: 'MainMenu' });
@@ -8,49 +10,8 @@ export default class MainMenu extends Phaser.Scene {
     }
 
     create() {
-        // Инициализация объекта данных
-        if (!this.registry.has('gameData')) {
-            this.registry.set('gameData', {
-                levelCount: 1,
-                health: 30,
-                experience: 0,
-                skills: {
-                    small_guns: 75,
-                    big_guns: 75,
-                    energy_weapons: 75,
-                    melee_weapons: 75,
-                    pyrotechnics: 75,
-                    lockpick: 75,
-                    science: 75,
-                    repair: 75,
-                    medcine: 75,
-                    barter: 75,
-                    speech: 75,
-                    surviving: 75
-                },
-                current_weapon: 'Baseball bat',
-                current_armor: 'Leather Jacket',
-                weapons: ['Baseball bat', '9mm pistol'],
-                med: {
-                    first_aid_kit: 0,
-                    jet: 0,
-                    buffout: 0,
-                    mentats: 0,
-                    psycho: 0
-                },
-                ammo: {
-                    mm_9: 500,
-                    magnum_44: 12,
-                    mm_12: 0,
-                    mm_5_45: 0,
-                    energy_cell: 0,
-                    frag_grenade: 0
-                },
-                enemiesToCreate: [],
-                levelLoot: [],
-            });
-        }
-        this.gameData = this.registry.get('gameData');
+        GameData.init();
+        this.gameData = GameData.get();
         this.add.image(0, 0, 'background_menu').setOrigin(0, 0);
         let startButton = this.add.text(this.cameras.main.centerX, this.cameras.main.centerY, 'New game', { fill: '#0f0' })
             .setInteractive()

--- a/utils/GameData.js
+++ b/utils/GameData.js
@@ -1,0 +1,71 @@
+const defaultGameData = {
+    levelCount: 1,
+    health: 30,
+    experience: 0,
+    skills: {
+        small_guns: 75,
+        big_guns: 75,
+        energy_weapons: 75,
+        melee_weapons: 75,
+        pyrotechnics: 75,
+        lockpick: 75,
+        science: 75,
+        repair: 75,
+        medcine: 75,
+        barter: 75,
+        speech: 75,
+        surviving: 75
+    },
+    current_weapon: 'Baseball bat',
+    current_armor: 'Leather Jacket',
+    weapons: ['Baseball bat', '9mm pistol'],
+    med: {
+        first_aid_kit: 0,
+        jet: 0,
+        buffout: 0,
+        mentats: 0,
+        psycho: 0
+    },
+    ammo: {
+        mm_9: 500,
+        magnum_44: 12,
+        mm_12: 0,
+        mm_5_45: 0,
+        energy_cell: 0,
+        frag_grenade: 0
+    },
+    enemiesToCreate: [],
+    levelLoot: [],
+    armorLoot: null
+};
+
+let gameData = null;
+
+function init() {
+    if (!gameData) {
+        gameData = JSON.parse(JSON.stringify(defaultGameData));
+    }
+}
+
+function get() {
+    if (!gameData) {
+        init();
+    }
+    return gameData;
+}
+
+function set(data) {
+    gameData = data;
+}
+
+function reset() {
+    gameData = JSON.parse(JSON.stringify(defaultGameData));
+}
+
+export default {
+    init,
+    get,
+    set,
+    reset,
+    getDefault: () => JSON.parse(JSON.stringify(defaultGameData))
+};


### PR DESCRIPTION
## Summary
- add `utils/GameData.js` with init/get/set helpers
- use `GameData` in `mainMenu.js` instead of Phaser registry
- import `GameData` across scenes and remove registry references

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68892d42f5f8832fa8136f216ccbbac7