### PR TITLE
Hide armor loot on victory

### DIFF
--- a/VictoryScene.js
+++ b/VictoryScene.js
@@ -64,7 +64,7 @@ export default class VictoryScene extends Phaser.Scene {
             if (lootIndex > currentIndex) {
                 this.gameData.current_armor = this.gameData.armorLoot;
             }
-            lootInfo[this.gameData.armorLoot] = 1;
+            // Броня применяется сразу, но не отображается среди лута
         }
 
         this.gameData.levelLoot.forEach(loot => {


### PR DESCRIPTION
## Summary
- keep new armor but don't show it in Victory scene

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688938e0ddec832fa124a2c073713210